### PR TITLE
Added get_eth_balance() & Documented module

### DIFF
--- a/examples/02_transfer.py
+++ b/examples/02_transfer.py
@@ -1,46 +1,150 @@
+import os
+
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
-from eth_typing import HexStr
+from eth_typing import HexStr, HexAddress
+from eth_utils import to_checksum_address
 from web3 import Web3
 
-from examples.utils import EnvPrivateKey
-from zksync2.core.types import ZkBlockParams
+from zksync2.core.types import ZkBlockParams, EthBlockParams
 from zksync2.module.module_builder import ZkSyncBuilder
 from zksync2.signer.eth_signer import PrivateKeyEthSigner
 from zksync2.transaction.transaction_builders import TxFunctionCall
 
-ZKSYNC_TEST_URL = "http://127.0.0.1:3050"
-ETH_TEST_URL = "http://127.0.0.1:8545"
+
+# Byte-format private key
+PRIVATE_KEY = bytes.fromhex(os.environ.get("PRIVATE_KEY"))
 
 
-def transfer_native_to_self(amount: float):
-    env = EnvPrivateKey("ZKSYNC_TEST_KEY")
-    web3 = ZkSyncBuilder.build(ZKSYNC_TEST_URL)
-    account: LocalAccount = Account.from_key(env.key)
-    chain_id = web3.zksync.chain_id
+def get_eth_balance(zk_web3: ZkSyncBuilder, address: HexAddress) -> float:
+    """
+    Get ETH balance of ETH address on zkSync network
+
+    :param zk_web3:
+        Instance of ZkSyncBuilder that interacts with zkSync network
+
+    :param address:
+       ETH address that you want to get balance of.
+
+    :return:
+       Balance of ETH address.
+
+    """
+
+    # Get WEI balance of ETH address
+    balance_wei = zk_web3.zksync.get_balance(
+        address,
+        EthBlockParams.LATEST.value
+        )
+
+    # Convert WEI balance to ETH
+    balance_eth = Web3.from_wei(balance_wei, "ether")
+
+    # Return the ETH balance of the ETH address
+    return balance_eth
+
+
+def transfer_eth(
+    zk_web3: ZkSyncBuilder,
+    account: LocalAccount,
+    address: HexAddress,
+    amount: float
+) -> bytes:
+    """
+    Transfer ETH to a desired address on zkSync network
+
+    :param zk_web3:
+        Instance of ZkSyncBuilder that interacts with zkSync network
+
+    :param account:
+        From which account the transfer will be made
+
+    :param address:
+      Desired ETH address that you want to transfer to.
+
+    :param amount:
+      Desired ETH amount that you want to transfer.
+
+    :return:
+      The transaction hash of the deposit transaction.
+
+    """
+
+    # Get chain id of zkSync network
+    chain_id = zk_web3.zksync.chain_id
+
+    # Signer is used to generate signature of provided transaction
     signer = PrivateKeyEthSigner(account, chain_id)
 
-    nonce = web3.zksync.get_transaction_count(account.address, ZkBlockParams.COMMITTED.value)
-    gas_price = web3.zksync.gas_price
-    tx_func_call = TxFunctionCall(chain_id=chain_id,
-                                  nonce=nonce,
-                                  from_=account.address,
-                                  to=account.address,
-                                  value=Web3.to_wei(amount, 'ether'),
-                                  data=HexStr("0x"),
-                                  gas_limit=0,  # UNKNOWN AT THIS STATE
-                                  gas_price=gas_price,
-                                  max_priority_fee_per_gas=100000000)
-    estimate_gas = web3.zksync.eth_estimate_gas(tx_func_call.tx)
+    # Get nonce of ETH address on zkSync network
+    nonce = zk_web3.zksync.get_transaction_count(
+        account.address, ZkBlockParams.COMMITTED.value
+    )
+
+    # Get current gas price in Wei
+    gas_price = zk_web3.zksync.gas_price
+
+    # Create transaction
+    tx_func_call = TxFunctionCall(
+        chain_id=chain_id,
+        nonce=nonce,
+        from_=account.address,
+        to=to_checksum_address(address),
+        value=zk_web3.to_wei(amount, "ether"),
+        data=HexStr("0x"),
+        gas_limit=0,  # UNKNOWN AT THIS STATE
+        gas_price=gas_price,
+        max_priority_fee_per_gas=100000000,
+    )
+
+    # ZkSync transaction gas estimation
+    estimate_gas = zk_web3.zksync.eth_estimate_gas(tx_func_call.tx)
     print(f"Fee for transaction is: {estimate_gas * gas_price}")
 
+    # Convert transaction to EIP-712 format
     tx_712 = tx_func_call.tx712(estimate_gas)
-    singed_message = signer.sign_typed_data(tx_712.to_eip712_struct())
-    msg = tx_712.encode(singed_message)
-    tx_hash = web3.zksync.send_raw_transaction(msg)
-    tx_receipt = web3.zksync.wait_for_transaction_receipt(tx_hash, timeout=240, poll_latency=0.5)
-    print(f"Tx status: {tx_receipt['status']}")
+
+    # Sign message & encode it
+    signed_message = signer.sign_typed_data(tx_712.to_eip712_struct())
+
+    # Encode signed message
+    msg = tx_712.encode(signed_message)
+
+    # Transfer ETH
+    tx_hash = zk_web3.zksync.send_raw_transaction(msg)
+    print(f"Transaction hash is : {tx_hash.hex()}")
+
+    # Wait for transaction to be included in a block
+    tx_receipt = zk_web3.zksync.wait_for_transaction_receipt(
+        tx_hash, timeout=240, poll_latency=0.5
+    )
+    print(f"Tx status: {tx_receipt.status}")
+
+    # Return the transaction hash of the deposit
+    return tx_hash
 
 
 if __name__ == "__main__":
-    transfer_native_to_self(0.1)
+
+    # Set a provider
+    PROVIDER = "https://zksync2-testnet.zksync.dev"
+
+    # Connect to zkSync network
+    zk_web3 = ZkSyncBuilder.build(PROVIDER)
+
+    # Get account object by providing from private key
+    account: LocalAccount = Account.from_key(PRIVATE_KEY)
+
+    # Show balance before ETH transfer
+    print(f"Balance before transfer : {get_eth_balance(zk_web3, account.address)} ETH")
+
+    # Perform the ETH transfer
+    transfer_eth(
+        zk_web3,
+        account,
+        "0x14E16DB45aE0909cB356169E4AF86D55541BE18C",
+        0.01
+        )
+
+    # Show balance after ETH transfer
+    print(f"Balance after transfer : {get_eth_balance(zk_web3, account.address)} ETH")

--- a/examples/02_transfer.py
+++ b/examples/02_transfer.py
@@ -118,7 +118,7 @@ def transfer_eth(
     tx_receipt = zk_web3.zksync.wait_for_transaction_receipt(
         tx_hash, timeout=240, poll_latency=0.5
     )
-    print(f"Tx status: {tx_receipt.status}")
+    print(f"Tx status: {tx_receipt['status']}")
 
     # Return the transaction hash of the deposit
     return tx_hash


### PR DESCRIPTION
Hi.

I added a new function called `get_eth_balance()` to retrive the balance of an address.
I documented `02_transfer.py` module for a better understanding of new comers that want to work with this module.
`02_transfer.py` is black formatted and passes flake8 rules (except E501).

Also posted a short blog tutorial how to set up the dev environment and use the `02_transfer.py` module.
https://medium.com/@web3devrel/how-to-transfer-eth-using-zksync2-python-sdk-502744db7a16