### PR TITLE
Fix erc20 design

### DIFF
--- a/examples/03_transfer_erc20_token.py
+++ b/examples/03_transfer_erc20_token.py
@@ -1,90 +1,171 @@
+import os
+from decimal import Decimal
+
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
-from web3 import Web3
+from eth_typing import HexStr, HexAddress
 
-from examples.utils import EnvPrivateKey
-from zksync2.core.types import ZkBlockParams, ADDRESS_DEFAULT, Token
-from zksync2.manage_contracts.erc20_contract import ERC20Contract, ERC20Encoder
+from zksync2.core.types import ZkBlockParams
+from zksync2.manage_contracts.erc20_contract import ERC20ContractRead, ERC20Encoder, _erc_20_abi_default
 from zksync2.module.module_builder import ZkSyncBuilder
 from zksync2.signer.eth_signer import PrivateKeyEthSigner
 from zksync2.transaction.transaction_builders import TxFunctionCall
 
-ZKSYNC_TEST_URL = "https://zksync2-testnet.zksync.dev"
-ETH_TEST_URL = "https://rpc.ankr.com/eth_goerli"
-SERC20_Address = Web3.to_checksum_address("0xd782e03F4818A7eDb0bc5f70748F67B4e59CdB33")
+
+# Byte-format private key
+PRIVATE_KEY = bytes.fromhex(os.environ.get("PRIVATE_KEY"))
 
 
-class Colors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+def get_erc20_balance(
+    zk_web3: ZkSyncBuilder,
+    address: HexAddress,
+    contract_address: HexAddress,
+    abi
+) -> float:
+    """
+    Get ERC20 balance of ETH address on zkSync network
+
+    :param zk_web3:
+        Instance of ZkSyncBuilder that interacts with zkSync network
+
+    :param address:
+        ETH address that you want to get ERC-20 balance of.
+
+    :param contract_address:
+        ETH address that you want to get ERC-20 balance of.
+
+    :return:
+        ERC20 formated balance of the requested address
+    """
+
+    # Get readable contract instance
+    contract = ERC20ContractRead(
+        web3=zk_web3.zksync, contract_address=contract_address, abi=abi
+    )
+
+    # Get decimals of the contract
+    contract_decimals = contract.decimals()
+
+    # Query contract's balance
+    erc20_balance = contract.balance_of(address)
+
+    # Return Formated Balance
+    return float(Decimal(erc20_balance) / Decimal(10) ** contract_decimals)
 
 
-def transfer_erc20(amount: float):
-    env1 = EnvPrivateKey("ZKSYNC_TEST_KEY")
-    env2 = EnvPrivateKey("ZKSYNC_TEST_KEY2")
-    web3 = ZkSyncBuilder.build(ZKSYNC_TEST_URL)
-    alice: LocalAccount = Account.from_key(env1.key)
-    bob: LocalAccount = Account.from_key(env2.key)
-    chain_id = web3.zksync.chain_id
-    signer = PrivateKeyEthSigner(alice, chain_id)
+def transfer_erc20(
+    zk_web3: ZkSyncBuilder,
+    account: LocalAccount,
+    to: HexAddress,
+    contract_address: HexAddress,
+    amount: int,
+) -> HexStr:
+    """
+    Transfer ERC20 token to a specific address on zkSync network
 
-    erc20_token = Token(l1_address=ADDRESS_DEFAULT,
-                        l2_address=SERC20_Address,
-                        symbol="SERC20",
-                        decimals=18)
-    erc20 = ERC20Contract(web3=web3.zksync,
-                          contract_address=erc20_token.l2_address,
-                          account=alice)
+    :param zk_web3:
+        Instance of ZkSyncBuilder that interacts with zkSync network.
 
-    alice_balance_before = erc20.balance_of(alice.address)
-    bob_balance_before = erc20.balance_of(bob.address)
-    print(f"Alice {erc20_token.symbol} balance before : {erc20_token.format_token(alice_balance_before)}")
-    print(f"Bob {erc20_token.symbol} balance before : {erc20_token.format_token(bob_balance_before)}")
+    :param account:
+        From which account the transfer will be made.
 
-    erc20_encoder = ERC20Encoder(web3)
-    transfer_params = (bob.address, erc20_token.to_int(amount))
+    :param to:
+        ETH address that you want to transfer tokens to.
+
+    :param contract_address:
+        ERC-20 contract address that the transfer will be made within.
+
+    :param amount:
+        ERC-20 token amount to be sent.
+
+    :return:
+        The transaction hash of the deposit transaction.
+    """
+
+    # Get chain id of zkSync network
+    chain_id = zk_web3.zksync.chain_id
+
+    # Signer is used to generate signature of provided transaction
+    signer = PrivateKeyEthSigner(account, chain_id)
+
+    # Get current gas price in Wei
+    gas_price = zk_web3.zksync.gas_price
+
+    # Get nonce of ETH address on zkSync network
+    nonce = zk_web3.zksync.get_transaction_count(
+        account.address, ZkBlockParams.COMMITTED.value
+    )
+
+    erc20_encoder = ERC20Encoder(zk_web3)
+
+    # Transfer parameters
+    transfer_params = (to, amount)
+
+    # Encode arguments
     call_data = erc20_encoder.encode_method("transfer", args=transfer_params)
 
-    nonce = web3.zksync.get_transaction_count(alice.address, ZkBlockParams.COMMITTED.value)
+    # Create transaction
+    func_call = TxFunctionCall(
+        chain_id=chain_id,
+        nonce=nonce,
+        from_=account.address,
+        to=contract_address,
+        data=call_data,
+        gas_limit=0,  # UNKNOWN AT THIS STATE
+        gas_price=gas_price,
+        max_priority_fee_per_gas=100000000,
+    )
 
-    gas_price = web3.zksync.gas_price
-    func_call = TxFunctionCall(chain_id=chain_id,
-                               nonce=nonce,
-                               from_=alice.address,
-                               to=erc20_token.l2_address,
-                               data=call_data,
-                               gas_limit=0,  # UNKNOWN AT THIS STATE
-                               gas_price=gas_price,
-                               max_priority_fee_per_gas=100000000)
-
-    estimate_gas = web3.zksync.eth_estimate_gas(func_call.tx)
+    # ZkSync transaction gas estimation
+    estimate_gas = zk_web3.zksync.eth_estimate_gas(func_call.tx)
     print(f"Fee for transaction is: {estimate_gas * gas_price}")
+
+    # Convert transaction to EIP-712 format
     tx_712 = func_call.tx712(estimated_gas=estimate_gas)
-    singed_message = signer.sign_typed_data(tx_712.to_eip712_struct())
-    msg = tx_712.encode(singed_message)
-    tx_hash = web3.zksync.send_raw_transaction(msg)
-    tx_receipt = web3.zksync.wait_for_transaction_receipt(tx_hash, timeout=240, poll_latency=0.5)
+    print(f"Tx 712 : {tx_712}")
+
+    # Sign message & encode it
+    signed_message = signer.sign_typed_data(tx_712.to_eip712_struct())
+    print(f"Signed tx 712 : {signed_message}")
+
+    # Encode signed message
+    msg = tx_712.encode(signed_message)
+    print(f"Msg  : {msg}")
+
+    # Transfer ERC-20 token
+    tx_hash = zk_web3.zksync.send_raw_transaction(msg)
+
+    # Wait for transaction to be included in a block
+    tx_receipt = zk_web3.zksync.wait_for_transaction_receipt(
+        tx_hash, timeout=240, poll_latency=0.5
+    )
     print(f"Tx status: {tx_receipt['status']}")
     print(f"Tx hash: {tx_receipt['transactionHash'].hex()}")
 
-    alice_balance_after = erc20.balance_of(alice.address)
-    bob_balance_after = erc20.balance_of(bob.address)
-    print(f"Alice {erc20_token.symbol} balance before : {erc20_token.format_token(alice_balance_after)}")
-    print(f"Bob {erc20_token.symbol} balance before : {erc20_token.format_token(bob_balance_after)}")
-
-    if bob_balance_after == bob_balance_before + erc20_token.to_int(amount) and \
-            alice_balance_after == alice_balance_before - erc20_token.to_int(amount):
-        print(f"{Colors.OKGREEN}{amount} of {erc20_token.symbol} tokens have been transferred{Colors.ENDC}")
-    else:
-        print(f"{Colors.FAIL}{erc20_token.symbol} transfer has failed{Colors.ENDC}")
-
 
 if __name__ == "__main__":
-    transfer_erc20(1)
+    # Some ERC20 Address
+    SERC20_Address = "0xd782e03F4818A7eDb0bc5f70748F67B4e59CdB33"
+
+    # Connect to zkSync provider
+    zk_web3 = ZkSyncBuilder.build("https://zksync2-testnet.zksync.dev")
+
+    # Get account object by providing byte-format private key
+    account: LocalAccount = Account.from_key(PRIVATE_KEY)
+
+    print(
+        f"ERC-20 Balance before transfer : {get_erc20_balance(zk_web3=zk_web3, address=account.address, contract_address=SERC20_Address, abi=_erc_20_abi_default())}"
+    )
+
+    # Perform ERC-20 transfer
+    transfer_erc20(
+        zk_web3=zk_web3,
+        account=account,
+        to="0xB8301fB6C3948C23D21ba68e1bD355F87168Bbe8",
+        contract_address=SERC20_Address,
+        amount=1,
+    )
+
+    print(
+        f"ERC-20 Balance after transfer : {get_erc20_balance(zk_web3=zk_web3, address=account.address, contract_address=SERC20_Address, abi=_erc_20_abi_default())}"
+    )

--- a/zksync2/manage_contracts/erc20_contract.py
+++ b/zksync2/manage_contracts/erc20_contract.py
@@ -1,13 +1,13 @@
 import json
 import importlib.resources as pkg_resources
 from typing import Optional
-from eth_typing import HexStr
+from eth_typing import HexStr, HexAddress
 from web3 import Web3
-from web3.module import Module
-from eth_account.signers.base import BaseAccount
 from web3.types import TxReceipt
 from zksync2.manage_contracts.contract_encoder_base import BaseContractEncoder
 from zksync2.manage_contracts import contract_abi
+from eth_account.signers.local import LocalAccount
+
 
 erc_20_abi_cache = None
 
@@ -17,72 +17,112 @@ def _erc_20_abi_default():
 
     if erc_20_abi_cache is None:
         with pkg_resources.path(contract_abi, "IERC20.json") as p:
-            with p.open(mode='r') as json_file:
+            with p.open(mode="r") as json_file:
                 data = json.load(json_file)
-                erc_20_abi_cache = data['abi']
+                erc_20_abi_cache = data["abi"]
     return erc_20_abi_cache
 
 
 class ERC20Contract:
+    """
+    Interact with ERC-20 Contract
+    """
+
     MAX_ERC20_APPROVE_AMOUNT = 2 ^ 256 - 1
     ERC20_APPROVE_THRESHOLD = 2 ^ 255
 
-    def __init__(self, web3: Module,
-                 contract_address: HexStr,
-                 account: BaseAccount):
-        check_sum_address = Web3.to_checksum_address(contract_address)
-        self.contract_address = check_sum_address
-        self.module = web3
-        self.contract = self.module.contract(self.contract_address, abi=_erc_20_abi_default())
+    def __init__(self, web3: Web3, contract_address: HexStr, abi):
+        self.web3 = web3
+        self.contract_address = contract_address
+        self.abi = abi
+        self.contract = self.web3.contract(self.contract_address, abi=self.abi)
+
+
+class ERC20ContractRead(ERC20Contract):
+    """
+    Read ERC-20 Contract information
+    """
+
+    def name(self) -> str:
+        return self.contract.functions.name().call(
+            {
+                "chainId": self.web3.chain_id,
+            }
+        )
+
+    def total_supply(self) -> int:
+        return self.contract.functions.totalSupply().call(
+            {
+                "chainId": self.web3.chain_id,
+            }
+        )
+
+    def decimals(self) -> int:
+        return self.contract.functions.decimals().call(
+            {
+                "chainId": self.web3.chain_id,
+            }
+        )
+
+    def balance_of(self, addr: HexStr) -> int:
+        return self.contract.functions.balanceOf(addr).call()
+
+    def symbol(self) -> str:
+        return self.contract.functions.symbol().call(
+            {
+                "chainId": self.web3.chain_id,
+            }
+        )
+
+    def allowance(self, owner: HexStr, sender: HexStr) -> int:
+        return self.contract.functions.allowance(owner, sender).call(
+            {
+                "chainId": self.web3.chain_id,
+            }
+        )
+
+
+class ERC20ContractWrite(ERC20Contract):
+    """
+    Make actions within ERC-20 Contract
+    """
+
+    def __init__(
+        self, account: LocalAccount, web3: Web3, contract_address: HexAddress, abi
+    ):
         self.account = account
+        super().__init__(web3, contract_address, abi)
 
     def _nonce(self) -> int:
         return self.module.get_transaction_count(self.account.address)
 
-    def approve(self,
-                zksync_address: HexStr,
-                amount,
-                gas_limit: int) -> TxReceipt:
+    def approve(self, zksync_address: HexStr, amount, gas_limit: int) -> TxReceipt:
         nonce = self._nonce()
         gas_price = self.module.gas_price
-        tx = self.contract.functions.approve(zksync_address,
-                                             amount).build_transaction(
+        tx = self.contract.functions.approve(zksync_address, amount).build_transaction(
             {
                 "chainId": self.module.chain_id,
                 "from": self.account.address,
                 "gasPrice": gas_price,
                 "gas": gas_limit,
-                "nonce": nonce
-            })
+                "nonce": nonce,
+            }
+        )
         signed_tx = self.account.sign_transaction(tx)
         tx_hash = self.module.send_raw_transaction(signed_tx.rawTransaction)
         tx_receipt = self.module.wait_for_transaction_receipt(tx_hash)
         return tx_receipt
 
-    def allowance(self, owner: HexStr, sender: HexStr) -> int:
-        return self.contract.functions.allowance(owner, sender).call(
-            {
-                "chainId": self.module.chain_id,
-                "from": self.account.address,
-            })
-
     def transfer(self, _to: str, _value: int):
         return self.contract.functions.transfer(_to, _value).call(
             {
-                "chainId": self.module.chain_id,
-                "from": self.account.address,
-            })
-
-    def balance_of(self, addr: HexStr):
-        return self.contract.functions.balanceOf(addr).call(
-            {
-                "chainId": self.module.chain_id,
+                "chainId": self.web3.chain_id, 
                 "from": self.account.address
-            })
+            }
+        )
 
 
 class ERC20Encoder(BaseContractEncoder):
-
     def __init__(self, web3: Web3, abi: Optional[dict] = None):
         if abi is None:
             abi = _erc_20_abi_default()


### PR DESCRIPTION

Hi. I discovered few issues with the design of `ERC20Contract` class and `examples/03_transfer_erc20_token.py` module

Inside of `transfer_erc20()` function from `examples.03_transfer_erc20_token` the `ERC20Contract` class instantiation needs an `account` argument.

```py
erc20 = ERC20Contract(web3=web3.zksync,
                          contract_address=erc20_token.l2_address,
                          account=alice)
bob_balance_before = erc20.balance_of(bob.address)
```

`bob_balance_before` uses `erc20=ERC20Contract(... account=alice)` object instantiation that contains Alice's account object
My problem with the class design is that we need to provide an account identity in order to retrieve someone else balance from a public network so I did the following things:

- I replaced `ERC20Contract` constructor `account` parameter with `abi` parameter since the class does not let the user to inject his own ABI contract + I think we do not need an account object for just retriving information from the contract.
By default every ERC20Contract() instantiation comes with `_erc_20_abi_default()`. I think letting the user to define his contract ABI preference is better than blocking him to the default one `_erc_20_abi_default()`.


- I seggregated `ERC20Contract` into 2 subclasses : `ERC20ContractRead` subclass and `ERC20ContractWrite` subclass 

`ERC20ContractRead` subclass job is to retrive information from the contract 
Also added to `ERC20ContractRead` subclass new methods such as : `name()`, `total_supply()`, `decimals()` and `symbol()`
`ERC20ContractWrite` subclass job is make actions within ERC-20 contract.
Both subclasses `ERC20ContractRead` and `ERC20ContractWrite` inherits from `ERC20Contract`.
I didn't make any changes to the `ERC20ContractWrite` methods since I still do not understand why we need `build_transaction()` for `approve()` method and for `transfer()` method not.

Modified `examples/03_transfer_erc20_token.py` module by removing irrelevant stuff from `transfer_erc20()` function and also added `get_erc20_balance()` function.
Both `transfer_erc20()` and `get_erc20_balance()` functions are now documented, modular and can be easily decoupled.
`zksync2/manage_contracts/erc20_contract.py` is now black formatted and passes flake8 rules (except E501)
`examples/03_transfer_erc20_token.py` module` is now black formatted and passes flake8 rules (except E501)


Example how to use use `ERC20Contract` class from `zksync2.manage_contracts.erc20_contract` module :

```py
from zksync2.manage_contracts.erc20_contract import ERC20ContractRead, _erc_20_abi_default
from zksync2.module.module_builder import ZkSyncBuilder

SERC20_Address = "0xd782e03F4818A7eDb0bc5f70748F67B4e59CdB33"
zk_web3 = ZkSyncBuilder.build("https://zksync2-testnet.zksync.dev")
read_contract = ERC20ContractRead(
    web3=zk_web3.zksync, contract_address=SERC20_Address, abi=_erc_20_abi_default()
)

print(read_contract.name())
print(read_contract.balance_of("0xf8ee193704c4EeA11085b64e4547c152EdD5a2C3"))
print(read_contract.decimals())
print(read_contract.symbol())
print(read_contract.total_supply())
```
