### PR TITLE
Fix withdrawal example

### DIFF
--- a/examples/11_withdrawal.py
+++ b/examples/11_withdrawal.py
@@ -11,7 +11,23 @@ from zksync2.transaction.transaction_builders import TxWithdraw
 
 
 def withdraw_to_l1(zk_web3: ZkSyncBuilder, account: LocalAccount, amount: float) -> HexStr:
+    """Withdraw from Layer 2 to Layer 1 on zkSync network
+    
+    :param zk_web3:
+        Instance of ZkSyncBuilder
+    
+    :param account:
+        From which ETH account the withdrawal will be made
+    
+    :param amount:
+        How much would the withdrawal will contain
+    
+    :return:
+        Transaction hash of the withdrawal
+    
+    """
 
+    # Create withdrawal transaction
     withdrawal = TxWithdraw(web3=zk_web3,
                             token=Token.create_eth(),
                             amount=Web3.to_wei(amount, "ether"),
@@ -19,32 +35,36 @@ def withdraw_to_l1(zk_web3: ZkSyncBuilder, account: LocalAccount, amount: float)
                             account=account
                             )
     
-
+    # ZkSync transaction gas estimation
     estimated_gas = zk_web3.zksync.eth_estimate_gas(withdrawal.tx)
 
-
+    # Estimate gas transaction
     tx = withdrawal.estimated_gas(estimated_gas)
     
-
+    # Sign the transaction
     signed = account.sign_transaction(tx)
 
+    # Broadcast the transaction to the network
     tx_hash = zk_web3.zksync.send_raw_transaction(signed.rawTransaction)
 
+    # Return the transaction hash of the withdrawal
     return tx_hash
 
 
 if __name__ == "__main__":
-
+    # Get the private key from OS environment variables
     PRIVATE_KEY = bytes.fromhex(os.environ.get("PRIVATE_KEY"))
 
+    # Set a provider
     PROVIDER = "https://zksync2-testnet.zksync.dev"
 
-
+    # Connect to zkSync network
     zk_web3 = ZkSyncBuilder.build(PROVIDER)
 
-
+    # Get account object by providing from private key
     account: LocalAccount = Account.from_key(PRIVATE_KEY)
 
+    # Perform the withdraw
     withdraw_to_l1(zk_web3, account, 0.01)
 
 

--- a/examples/11_withdrawal.py
+++ b/examples/11_withdrawal.py
@@ -1,9 +1,8 @@
 import os
 
+from web3 import Web3
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
-from eth_typing import HexStr
-from web3 import Web3
 
 from zksync2.core.types import Token
 from zksync2.module.module_builder import ZkSyncBuilder
@@ -12,7 +11,7 @@ from zksync2.transaction.transaction_builders import TxWithdraw
 
 def withdraw_to_l1(
     zk_web3: ZkSyncBuilder, account: LocalAccount, amount: float
-) -> HexStr:
+) -> bytes:
     """Withdraw from Layer 2 to Layer 1 on zkSync network
 
     :param zk_web3:
@@ -68,4 +67,4 @@ if __name__ == "__main__":
     account: LocalAccount = Account.from_key(PRIVATE_KEY)
 
     # Perform the withdraw
-    withdraw_to_l1(zk_web3, account, 0.01)
+    print(withdraw_to_l1(zk_web3, account, 0.01).hex())

--- a/examples/11_withdrawal.py
+++ b/examples/11_withdrawal.py
@@ -10,37 +10,40 @@ from zksync2.module.module_builder import ZkSyncBuilder
 from zksync2.transaction.transaction_builders import TxWithdraw
 
 
-def withdraw_to_l1(zk_web3: ZkSyncBuilder, account: LocalAccount, amount: float) -> HexStr:
+def withdraw_to_l1(
+    zk_web3: ZkSyncBuilder, account: LocalAccount, amount: float
+) -> HexStr:
     """Withdraw from Layer 2 to Layer 1 on zkSync network
-    
+
     :param zk_web3:
         Instance of ZkSyncBuilder
-    
+
     :param account:
         From which ETH account the withdrawal will be made
-    
+
     :param amount:
         How much would the withdrawal will contain
-    
+
     :return:
         Transaction hash of the withdrawal
-    
+
     """
 
     # Create withdrawal transaction
-    withdrawal = TxWithdraw(web3=zk_web3,
-                            token=Token.create_eth(),
-                            amount=Web3.to_wei(amount, "ether"),
-                            gas_limit=0,  # unknown
-                            account=account
-                            )
-    
+    withdrawal = TxWithdraw(
+        web3=zk_web3,
+        token=Token.create_eth(),
+        amount=Web3.to_wei(amount, "ether"),
+        gas_limit=0,  # unknown
+        account=account,
+    )
+
     # ZkSync transaction gas estimation
     estimated_gas = zk_web3.zksync.eth_estimate_gas(withdrawal.tx)
 
     # Estimate gas transaction
     tx = withdrawal.estimated_gas(estimated_gas)
-    
+
     # Sign the transaction
     signed = account.sign_transaction(tx)
 
@@ -66,8 +69,3 @@ if __name__ == "__main__":
 
     # Perform the withdraw
     withdraw_to_l1(zk_web3, account, 0.01)
-
-
-
-
-

--- a/examples/11_withdrawal.py
+++ b/examples/11_withdrawal.py
@@ -1,72 +1,53 @@
+import os
+
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
+from eth_typing import HexStr
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
 
-from examples.utils import EnvPrivateKey
 from zksync2.core.types import Token
 from zksync2.module.module_builder import ZkSyncBuilder
-from zksync2.provider.eth_provider import EthereumProvider
 from zksync2.transaction.transaction_builders import TxWithdraw
 
-ZKSYNC_TEST_URL = "http://127.0.0.1:3050"
-ETH_TEST_URL = "http://127.0.0.1:8545"
 
+def withdraw_to_l1(zk_web3: ZkSyncBuilder, account: LocalAccount, amount: float) -> HexStr:
 
-class Colors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
-
-
-def example_withdrawal(amount: float):
-    env = EnvPrivateKey("ZKSYNC_TEST_KEY")
-    web3 = ZkSyncBuilder.build(ZKSYNC_TEST_URL)
-    account: LocalAccount = Account.from_key(env.key)
-
-    eth_web3 = Web3(Web3.HTTPProvider(ETH_TEST_URL))
-    eth_web3.middleware_onion.inject(geth_poa_middleware, layer=0)
-
-    eth_balance = eth_web3.eth.get_balance(account.address)
-    print(f"Eth: balance: {Web3.from_wei(eth_balance, 'ether')}")
-
-    eth_provider = EthereumProvider(web3,
-                                    eth_web3,
-                                    account)
-    withdrawal = TxWithdraw(web3=web3,
+    withdrawal = TxWithdraw(web3=zk_web3,
                             token=Token.create_eth(),
                             amount=Web3.to_wei(amount, "ether"),
                             gas_limit=0,  # unknown
-                            account=account)
-    estimated_gas = web3.zksync.eth_estimate_gas(withdrawal.tx)
+                            account=account
+                            )
+    
+
+    estimated_gas = zk_web3.zksync.eth_estimate_gas(withdrawal.tx)
+
+
     tx = withdrawal.estimated_gas(estimated_gas)
+    
+
     signed = account.sign_transaction(tx)
-    tx_hash = web3.zksync.send_raw_transaction(signed.rawTransaction)
-    zks_receipt = web3.zksync.wait_finalized(tx_hash, timeout=240, poll_latency=0.5)
-    print(f"ZkSync Tx status: {zks_receipt['status']}")
-    tx_receipt = eth_provider.finalize_withdrawal(zks_receipt["transactionHash"])
-    print(f"Finalize withdrawal, Tx status: {tx_receipt['status']}")
 
-    prev = eth_balance
-    eth_balance = eth_web3.eth.get_balance(account.address)
-    print(f"Eth: balance: {Web3.from_wei(eth_balance, 'ether')}")
+    tx_hash = zk_web3.zksync.send_raw_transaction(signed.rawTransaction)
 
-    fee = tx_receipt['gasUsed'] * tx_receipt['effectiveGasPrice']
-    withdraw_absolute = Web3.to_wei(amount, 'ether') - fee
-    diff = eth_balance - prev
-    if withdraw_absolute == diff:
-        print(f"{Colors.OKGREEN}Withdrawal including tx fee is passed{Colors.ENDC}")
-        print(f"{Colors.OKGREEN}Eth diff with fee included: {Web3.from_wei(diff, 'ether')}{Colors.ENDC}")
-    else:
-        print(f"P{Colors.FAIL}Withdrawal failed{Colors.ENDC}")
-        print(f"{Colors.FAIL}Eth diff with fee included: {Web3.from_wei(diff, 'ether')}{Colors.ENDC}")
+    return tx_hash
 
 
 if __name__ == "__main__":
-    example_withdrawal(0.1)
+
+    PRIVATE_KEY = bytes.fromhex(os.environ.get("PRIVATE_KEY"))
+
+    PROVIDER = "https://zksync2-testnet.zksync.dev"
+
+
+    zk_web3 = ZkSyncBuilder.build(PROVIDER)
+
+
+    account: LocalAccount = Account.from_key(PRIVATE_KEY)
+
+    withdraw_to_l1(zk_web3, account, 0.01)
+
+
+
+
+


### PR DESCRIPTION
Hi

I found a bug in withdrawal example module. Whenever someone tries to run the example module they will always get timed out exception `web3.exceptions.TimeExhausted` due to slow speed of verifying txs on L2 so I refactored and documented the withdrawal example module and also posted a new blog tutorial about setting this up:

https://medium.com/@web3devrel/how-to-withdraw-eth-from-l2-to-l1-using-zksync2-python-sdk-b0a7ecb933ac