### PR TITLE
fix: relax web3 version restriction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 eip712_structs == 1.1.0
-web3==6.0.0
+web3>=6.3.0
 eth-tester
 black

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,9 +10,9 @@ license = MIT
 packages = find:
 install_requires =
     eip712_structs == 1.1.0
-    web3==6.0.0
+    web3>=6.3.0
 
-python_requires = >=3.10
+python_requires = >=3.8
 setup_requires =
 	setuptools_scm >= v7.0.5
 


### PR DESCRIPTION
# What :computer: 
* Be less restrictive on the `web3` version.
* Fixes #45 
* Uniformized the minimal Python version supported (no behavior change though).

# Why :hand:
* To be able to use that module into bigger projects where `web3` is already installed with newer version.
* To fix the related issue at the same time.
