### PR TITLE
fix: move to a modern EIP-712 structs module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-eip712_structs == 1.1.0
+eip712_structs_ng >= 2.0.1
 web3==6.0.0
 eth-tester
 black

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 eip712_structs_ng >= 2.0.1
-web3==6.0.0
 web3>=6.3.0
 eth-tester
 black

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ license = MIT
 [options]
 packages = find:
 install_requires =
-    eip712_structs == 1.1.0
+    eip712_structs_ng >= 2.0.1
     web3==6.0.0
 
 python_requires = >=3.10


### PR DESCRIPTION
# What :computer: 
* changed the EIP-712 module to a [newer one](https://pypi.org/project/eip712-structs-ng/)

# Why :hand:
* fixes #3
* fixes #43

# Notes :memo:

The API does not change, it is a **drop-in replacement**, and as a bonus it unlocks Python 3.11 & 3.12 support.

