### PR TITLE
fix: non zero gas limit in options breaks transfer function

### DIFF
--- a/zksync2/account/wallet_l2.py
+++ b/zksync2/account/wallet_l2.py
@@ -101,10 +101,12 @@ class WalletL2:
         tx_fun_call = self._zksync_web3.zksync.get_transfer_transaction(
             tx, self._l1_account.address
         )
-        if tx.options.gas_limit == 0:
-            tx_712 = tx_fun_call.tx712(
-                self._zksync_web3.zksync.zks_estimate_gas_transfer(tx_fun_call.tx)
-            )
+        estimated_gas = self._zksync_web3.zksync.zks_estimate_gas_transfer(
+            tx_fun_call.tx
+        )
+        tx_712 = tx_fun_call.tx712(
+            estimated_gas if tx.options.gas_limit == 0 else tx.options.gas_limit
+        )
         signer = PrivateKeyEthSigner(self._l1_account, tx.options.chain_id)
         signed_message = signer.sign_typed_data(tx_712.to_eip712_struct())
 


### PR DESCRIPTION
# What :computer: 
Allow to specify the gas limit when making a transfer tx

# Why :hand:
If `tx.options.gas_limit` is not 0,[ no `tx_712` variable will be created](https://github.com/zksync-sdk/zksync2-python/blob/v1.1.0/zksync2/account/wallet_l2.py#L104) and the function `transfer()` breaks at [here](https://github.com/zksync-sdk/zksync2-python/blob/v1.1.0/zksync2/account/wallet_l2.py#L109)

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?

