### PR TITLE
fix: zks_l1_chain_id not returning int type

### DIFF
--- a/tests/integration/test_zksync_web3.py
+++ b/tests/integration/test_zksync_web3.py
@@ -770,7 +770,7 @@ class ZkSyncWeb3Tests(TestCase):
 
     # @skip("Integration test, used for develop purposes only")
     def test_get_l1_chain_id(self):
-        l1_chain_id = self.web3.zksync.zks_l1_chain_id()
+        self.assertIsInstance(self.web3.zksync.zks_l1_chain_id(), int)
 
     # @skip("Integration test, used for develop purposes only")
     def test_get_bridge_addresses(self):

--- a/zksync2/module/zksync_module.py
+++ b/zksync2/module/zksync_module.py
@@ -525,7 +525,7 @@ class ZkSync(Eth, ABC):
         return self._zks_get_token_price(token_address)
 
     def zks_l1_chain_id(self) -> int:
-        return self._zks_l1_chain_id()
+        return int(self._zks_l1_chain_id(), 16)
 
     def zks_get_balance(
         self,


### PR DESCRIPTION
# What :computer: 
`zks_l1_chain_id` is not returning `int`, it's returning the hex string

# Why :hand:
* Reason why first thing was added to PR
* Reason why second thing was added to PR
* Reason why third thing was added to PR

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?

